### PR TITLE
added ability to auto detect .vercel/project.json files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ A VS Code extension for Vercel deployment status.
 
 1. Install the extension from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=haydenbleasel.vercel-vscode) or with the terminal command `code --install-extension haydenbleasel.vercel-vscode`.
 2. Open the extension settings and enter your API token.
-3. Create a `.vscode/settings.json` file in your project and add the following:
+3. Open a workspace which uses the Vercel CLI(and has a .vercel/project.json), or create a `.vscode/settings.json` file in your project and add the following:
 
 ```json
 {
-  "vercel-vscode.project": "prj_myproject"
+  "vercel-vscode.project": "prj_myprojectID"
 }
 ```
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,7 +15,6 @@ const getProjectIdFromJson = async (): Promise<string | undefined> => {
   try {
     vercelProjectJson = await workspace.fs.readFile(fileUri);
   } catch {
-    await window.showErrorMessage('Could not find .vercel/project.json file.');
     return undefined;
   }
   try {
@@ -34,16 +33,6 @@ const getProjectIdFromJson = async (): Promise<string | undefined> => {
 let interval: NodeJS.Timer | null = null;
 
 export const activate = async (): Promise<void> => {
-  const access_token = workspace
-    .getConfiguration('vercel-vscode')
-    .get('access_token');
-
-  if (!access_token || typeof access_token !== 'string') {
-    await window.showErrorMessage(
-      'Please set your Vercel access token in the extension settings.'
-    );
-    return;
-  }
   let project: string | undefined = workspace
     .getConfiguration('vercel-vscode')
     .get('project');
@@ -56,6 +45,17 @@ export const activate = async (): Promise<void> => {
   if (!project || typeof project !== 'string') {
     return;
   }
+  const access_token = workspace
+    .getConfiguration('vercel-vscode')
+    .get('access_token');
+
+  if (!access_token || typeof access_token !== 'string') {
+    await window.showErrorMessage(
+      'Please set your Vercel access token in the extension settings.'
+    );
+    return;
+  }
+
   const statusBarItem = window.createStatusBarItem(
     StatusBarAlignment.Right,
     100


### PR DESCRIPTION
# What it does:
Allows this extension to automatically detect project ids from .vercel/project.json files if there is no setting defined. This allows for a global override to be set in (global)settings.json, or a workspace override to be set by creating a .vscode/settings.json file, just like before, but in the absence of either value, checks for a top level .vercel/project.json file (created by the Vercel CLI) to get the project id. 
### Reason for creation
Allows for more dynamic usage with the Vercel CLI(likely to already be in use by anyone utilizing this extension), and avoids unnecessary user effort in defining a project name in a seperate file for every Vercel app they edit.

### Shortfall
This would not be supported with projects that have their .vercel folder nested within another, however such users could set a value in their workspace settings file.

### What it solves: 
See issue #17 